### PR TITLE
docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ActivityPub and Mastodon compatible server running on Cloudflare Workers.
 
 > **Note**
+>
 > This project still in working.
 
 <!-- Link definitions -->

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![LICENSE][license-badge]][license]
 
-ActivityPub compatible server running on Cloudflare Worker.
+ActivityPub and Mastodon compatible server running on Cloudflare Workers.
 
-> **Note**  
+> **Note**
 > This project still in working.
 
 <!-- Link definitions -->


### PR DESCRIPTION
- Fix typo.
- Add words  "Mastodon compatible"